### PR TITLE
Add Streamlit app for African restaurant tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# AfricaX
+# AfricaX 🍽️
+
+AfricaX is a Streamlit-powered tasting passport that helps our crew track every African restaurant we visit in the DMV area. The app features an interactive Africa map, country highlights, and a filterable tasting log so we can celebrate where we've been and plan the next outing.
+
+## Features
+
+- **Africa choropleth** highlighting the countries represented in our tastings.
+- **Interactive restaurant map** with hoverable ratings, notes, and visit dates.
+- **Filter panel** to focus on specific countries, rating ranges, and visit windows.
+- **Downloadable tasting log** so the crew can export the current data.
+
+## Getting started
+
+1. Create and activate a virtual environment (optional but recommended).
+2. Install the dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Launch the Streamlit app:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+   The app will open in your browser at `http://localhost:8501`.
+
+## Updating the tasting log
+
+All restaurant visits live in [`data/restaurants.csv`](data/restaurants.csv). Add new rows with the country, ISO3 code, city, restaurant name, rating, visit date, notes, and coordinates. When the file updates, Streamlit reloads and displays the new spot immediately.
+
+## Deploying
+
+To share the experience with friends:
+
+- Deploy to [Streamlit Community Cloud](https://streamlit.io/cloud) for a quick, free option.
+- Or host it yourself and point a custom domain (e.g., via Netlify or Fly.io reverse proxy).
+
+Make sure to keep your `requirements.txt` updated so the deployment environment has everything it needs.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,161 @@
+from pathlib import Path
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+DATA_PATH = Path(__file__).parent / "data" / "restaurants.csv"
+
+st.set_page_config(
+    page_title="AfricaX Restaurant Tracker",
+    page_icon="🍽️",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+@st.cache_data
+def load_restaurants() -> pd.DataFrame:
+    df = pd.read_csv(DATA_PATH, parse_dates=["Visit Date"])
+    df.sort_values("Visit Date", ascending=False, inplace=True)
+    return df
+
+
+def compute_country_summary(df: pd.DataFrame) -> pd.DataFrame:
+    summary = (
+        df.groupby(["Country", "ISO_A3"], as_index=False)
+        .agg(
+            Visits=("Restaurant", "count"),
+            Average_Rating=("Rating", "mean"),
+            Latest_Visit=("Visit Date", "max"),
+        )
+        .sort_values("Visits", ascending=False)
+    )
+    summary["Average_Rating"] = summary["Average_Rating"].round(2)
+    return summary
+
+
+def africa_choropleth(summary: pd.DataFrame):
+    fig = px.choropleth(
+        summary,
+        locations="ISO_A3",
+        color="Visits",
+        hover_name="Country",
+        hover_data={
+            "Visits": True,
+            "Average_Rating": True,
+            "Latest_Visit": summary["Latest_Visit"].dt.strftime("%b %d, %Y"),
+            "ISO_A3": False,
+        },
+        color_continuous_scale="YlOrRd",
+        scope="africa",
+        title="Countries we've tasted",
+    )
+    fig.update_layout(margin=dict(l=0, r=0, t=60, b=0))
+    return fig
+
+
+def africa_restaurant_map(df: pd.DataFrame):
+    fig = px.scatter_geo(
+        df,
+        lat="Latitude",
+        lon="Longitude",
+        color="Rating",
+        size="Rating",
+        size_max=18,
+        hover_name="Restaurant",
+        hover_data={
+            "Country": True,
+            "City": True,
+            "Rating": True,
+            "Visit Date": df["Visit Date"].dt.strftime("%b %d, %Y"),
+            "Latitude": False,
+            "Longitude": False,
+        },
+        color_continuous_scale="deep",
+        range_color=(3.5, 5),
+        projection="natural earth",
+        scope="africa",
+        title="Restaurant stops",
+    )
+    fig.update_layout(margin=dict(l=0, r=0, t=60, b=0))
+    return fig
+
+
+def main():
+    df = load_restaurants()
+    summary = compute_country_summary(df)
+
+    st.title("🍽️ AfricaX – African Restaurant Passport")
+    st.markdown(
+        """
+        Track your journey as you taste your way across the African continent—one local spot at a time.
+        Filter by country, rating, or visit date to explore highlights from your adventures and plan where to go next.
+        """
+    )
+
+    with st.sidebar:
+        st.header("Filter your journey")
+        countries = st.multiselect(
+            "Countries", options=sorted(df["Country"].unique()), default=sorted(df["Country"].unique())
+        )
+        min_rating, max_rating = float(df["Rating"].min()), float(df["Rating"].max())
+        rating_range = st.slider(
+            "Rating", min_value=1.0, max_value=5.0, value=(min_rating, max_rating), step=0.1
+        )
+        min_date, max_date = df["Visit Date"].min(), df["Visit Date"].max()
+        visit_range = st.date_input(
+            "Visit window",
+            value=(min_date, max_date),
+            min_value=min_date,
+            max_value=max_date,
+        )
+        search_text = st.text_input("Search restaurants or notes")
+        st.info(
+            "Use the filters above to focus on the next country you want to explore or to revisit favorites."
+        )
+
+    filtered = df[df["Country"].isin(countries)]
+    filtered = filtered[(filtered["Rating"] >= rating_range[0]) & (filtered["Rating"] <= rating_range[1])]
+    filtered = filtered[
+        (filtered["Visit Date"] >= pd.to_datetime(visit_range[0]))
+        & (filtered["Visit Date"] <= pd.to_datetime(visit_range[1]))
+    ]
+    if search_text:
+        mask = filtered.apply(lambda row: search_text.lower() in row.to_string().lower(), axis=1)
+        filtered = filtered[mask]
+
+    st.subheader("Where have we been?")
+    st.plotly_chart(africa_choropleth(summary), use_container_width=True)
+
+    st.subheader("Restaurant map")
+    st.plotly_chart(africa_restaurant_map(filtered), use_container_width=True)
+
+    st.subheader("Tasting log")
+    st.dataframe(
+        filtered.assign(**{"Visit Date": filtered["Visit Date"].dt.strftime("%b %d, %Y")})[
+            ["Visit Date", "Country", "City", "Restaurant", "Rating", "Notes"]
+        ],
+        use_container_width=True,
+        hide_index=True,
+    )
+
+    st.markdown("---")
+    st.markdown("### Add your next spot")
+    st.markdown(
+        """
+        Ready to log another outing? Update `data/restaurants.csv` with the new country, restaurant, and coordinates.
+        Streamlit automatically reloads the data when the file changes, so you'll see the new pin on the map instantly when the app reruns.
+        """
+    )
+
+    st.markdown("#### Export your data")
+    st.download_button(
+        label="Download tasting log (CSV)",
+        data=df.to_csv(index=False),
+        file_name="africax_restaurants.csv",
+        mime="text/csv",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/data/restaurants.csv
+++ b/data/restaurants.csv
@@ -1,0 +1,11 @@
+Country,ISO_A3,City,Restaurant,Rating,Visit Date,Notes,Latitude,Longitude
+Ethiopia,ETH,Silver Spring,Lucy Ethiopian Restaurant,4.5,2024-02-10,"Incredible injera sampler with spicy kitfo.",38.9977,-77.0262
+Nigeria,NGA,Washington DC,Bukom Cafe,4.2,2024-03-05,"Lively atmosphere and tasty suya skewers.",38.9190,-77.0414
+Senegal,SEN,Arlington,Chez Dior,4.7,2024-01-18,"Thieboudienne was perfectly seasoned.",38.8904,-77.0844
+Ghana,GHA,Washington DC,Sankofa Cafe,4.0,2023-12-09,"Great jollof and smoothies; limited seating.",38.9491,-77.0251
+Morocco,MAR,Alexandria,Kasbah Moroccan Lounge,4.6,2024-04-12,"Beautiful decor and fragrant tagines.",38.8048,-77.0469
+Eritrea,ERI,Washington DC,Dukem Restaurant,4.3,2024-05-03,"Live music nights make it memorable.",38.9097,-77.0228
+Somalia,SOM,Alexandria,Sabah Restaurant,4.1,2024-02-24,"Savory sambusas and welcoming staff.",38.8048,-77.0469
+South Africa,ZAF,Washington DC,South Africa House,4.4,2024-01-28,"Bobotie with yellow rice was a standout.",38.9240,-77.0325
+Kenya,KEN,Silver Spring,Serengeti Restaurant,4.5,2024-03-22,"Nyama choma cooked to perfection.",38.9907,-77.0261
+Côte d'Ivoire,CIV,Hyattsville,Chez Dior Express,4.0,2024-04-30,"Attiéké and fried fish combo hit the spot.",38.9559,-76.9455

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit==1.32.2
+pandas==2.2.1
+plotly==5.19.0


### PR DESCRIPTION
## Summary
- add a Streamlit app that visualizes African restaurant visits on choropleth and point maps
- seed the project with a sample tasting log dataset and deployment dependencies
- update the README with setup, usage, and deployment instructions

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e5ab771504832eb17d371914a3c7f6